### PR TITLE
Add clear method

### DIFF
--- a/lib/mask_text_input_formatter.dart
+++ b/lib/mask_text_input_formatter.dart
@@ -63,6 +63,11 @@ class MaskTextInputFormatter extends TextInputFormatter {
     _lastResValue = _formatUpdate(oldValue, newValue);
     return _lastResValue;
   }
+  
+  /// Clear the text stored in the formatter
+  void clear() {
+    _resultTextArray.clear();
+  }
 
   TextEditingValue _formatUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
 


### PR DESCRIPTION
This adds functionality to clear the formatter as clearing the TextEditingController of the TextField or TextFormField that are using this formatter will yield strange behavior without also clearing the cached text of the formatter.